### PR TITLE
[GP-3444] Dump inhibitions to JSON and read them back again

### DIFF
--- a/src/main/java/ca/on/oicr/gsi/somnus/Inhibition.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Inhibition.java
@@ -55,7 +55,6 @@ class Inhibition implements Predicate<String>, Iterable<String> {
     return expirationTime;
   }
 
-  @JsonGetter("id")
   public int id() {
     return id;
   }

--- a/src/main/java/ca/on/oicr/gsi/somnus/Inhibition.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Inhibition.java
@@ -1,6 +1,8 @@
 package ca.on.oicr.gsi.somnus;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.Set;
@@ -18,12 +20,13 @@ class Inhibition implements Predicate<String>, Iterable<String> {
   private final String reason;
   private final Set<String> services;
 
+  @JsonCreator
   public Inhibition(
-      Set<String> services,
-      String environment,
-      Instant expirationTime,
-      String creator,
-      String reason) {
+      @JsonProperty("services") Set<String> services,
+      @JsonProperty("environment") String environment,
+      @JsonProperty("expirationTime") Instant expirationTime,
+      @JsonProperty("creator") String creator,
+      @JsonProperty("reason") String reason) {
     this.services = services;
     this.environment = environment;
     this.expirationTime = expirationTime;
@@ -70,7 +73,7 @@ class Inhibition implements Predicate<String>, Iterable<String> {
   }
 
   @JsonGetter("services")
-  private Set<String> services() {
+  public Set<String> services() {
     return services;
   }
 

--- a/src/main/java/ca/on/oicr/gsi/somnus/Inhibition.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Inhibition.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.somnus;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.Set;
@@ -34,22 +35,27 @@ class Inhibition implements Predicate<String>, Iterable<String> {
     return awoken;
   }
 
+  @JsonGetter("created")
   public Instant created() {
     return created;
   }
 
+  @JsonGetter("creator")
   public String creator() {
     return creator;
   }
 
+  @JsonGetter("environment")
   public String environment() {
     return environment;
   }
 
+  @JsonGetter("expirationTime")
   public Instant expirationTime() {
     return expirationTime;
   }
 
+  @JsonGetter("id")
   public int id() {
     return id;
   }
@@ -59,8 +65,14 @@ class Inhibition implements Predicate<String>, Iterable<String> {
     return services.iterator();
   }
 
+  @JsonGetter("reason")
   public String reason() {
     return reason;
+  }
+
+  @JsonGetter("services")
+  private Set<String> services() {
+    return services;
   }
 
   @Override

--- a/src/main/java/ca/on/oicr/gsi/somnus/Server.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Server.java
@@ -193,7 +193,7 @@ public final class Server implements ServerConfig {
               try {
                 final CreateRequest query =
                     mapper.readValue(t.getRequestBody(), CreateRequest.class);
-                if (validSubmission(
+                if (!validSubmission(
                     query.getCreator(), query.getEnvironment(), query.getServices())) {
                   t.sendResponseHeaders(400, 0);
                   try (final OutputStream os = t.getResponseBody()) {

--- a/src/main/java/ca/on/oicr/gsi/somnus/Server.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Server.java
@@ -244,14 +244,24 @@ public final class Server implements ServerConfig {
 
               break;
             case "GET":
-              ArrayNode inhibitionDump = mapper.createArrayNode();
-              for (Inhibition i : inhibitions) {
-                inhibitionDump.add(mapper.convertValue(i, ObjectNode.class));
-              }
-              t.getResponseHeaders().set("Content-type", "application/json");
-              t.sendResponseHeaders(200, 0);
-              try (final OutputStream os = t.getResponseBody()) {
-                os.write(mapper.writeValueAsBytes(inhibitionDump));
+              try {
+                ArrayNode inhibitionDump = mapper.createArrayNode();
+                for (Inhibition i : inhibitions) {
+                  inhibitionDump.add(mapper.convertValue(i, ObjectNode.class));
+                }
+                t.getResponseHeaders().set("Content-type", "application/json");
+                t.sendResponseHeaders(200, 0);
+                try (final OutputStream os = t.getResponseBody()) {
+                  os.write(mapper.writeValueAsBytes(inhibitionDump));
+                }
+              } catch (final Exception e) {
+                e.printStackTrace();
+                t.sendResponseHeaders(400, 0);
+                try (OutputStream os = t.getResponseBody()) {
+                  final ObjectNode result = mapper.createObjectNode();
+                  result.put("error", e.getMessage());
+                  os.write(mapper.writeValueAsBytes(result));
+                }
               }
           }
         });

--- a/src/main/java/ca/on/oicr/gsi/somnus/Server.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Server.java
@@ -4,6 +4,7 @@ import ca.on.oicr.gsi.prometheus.LatencyHistogram;
 import ca.on.oicr.gsi.status.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -239,6 +240,18 @@ public final class Server implements ServerConfig {
                   result.put("error", e.getMessage());
                   os.write(mapper.writeValueAsBytes(result));
                 }
+              }
+
+              break;
+            case "GET":
+              ArrayNode inhibitionDump = mapper.createArrayNode();
+              for (Inhibition i : inhibitions) {
+                inhibitionDump.add(mapper.convertValue(i, ObjectNode.class));
+              }
+              t.getResponseHeaders().set("Content-type", "application/json");
+              t.sendResponseHeaders(200, 0);
+              try (final OutputStream os = t.getResponseBody()) {
+                os.write(mapper.writeValueAsBytes(inhibitionDump));
               }
           }
         });

--- a/src/main/java/ca/on/oicr/gsi/somnus/Server.java
+++ b/src/main/java/ca/on/oicr/gsi/somnus/Server.java
@@ -251,8 +251,10 @@ public final class Server implements ServerConfig {
             case "GET":
               try {
                 ArrayNode inhibitionDump = mapper.createArrayNode();
+                Instant now = Instant.now();
                 for (Inhibition i : inhibitions) {
-                  inhibitionDump.add(mapper.convertValue(i, ObjectNode.class));
+                  if (i.expirationTime().isAfter(now) && !i.awoken())
+                    inhibitionDump.add(mapper.convertValue(i, ObjectNode.class));
                 }
                 t.getResponseHeaders().set("Content-type", "application/json");
                 t.sendResponseHeaders(200, 0);

--- a/src/main/resources/ca/on/oicr/gsi/somnus/swagger.json
+++ b/src/main/resources/ca/on/oicr/gsi/somnus/swagger.json
@@ -31,9 +31,6 @@
               }
             }
           },
-          "id": {
-            "type": "number"
-          },
           "reason": {
             "type": "string"
           },

--- a/src/main/resources/ca/on/oicr/gsi/somnus/swagger.json
+++ b/src/main/resources/ca/on/oicr/gsi/somnus/swagger.json
@@ -4,32 +4,16 @@
       "Inhibition": {
         "properties": {
           "created": {
-            "type": "object",
-            "properties": {
-              "nano": {
-                "type": "number"
-              },
-              "epochSecond": {
-                "type": "number"
-              }
-            }
+            "type": "number"
           },
           "creator": {
-            "type": "number"
+            "type": "string"
           },
           "environment": {
             "type": "string"
           },
           "expirationTime": {
-            "type": "object",
-            "properties": {
-              "nano": {
-                "type": "number"
-              },
-              "epochSecond": {
-                "type": "number"
-              }
-            }
+            "type": "number"
           },
           "reason": {
             "type": "string"
@@ -162,6 +146,26 @@
                 "schema": {
                   "$ref": "#/components/schemas/Inhibition"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/load": {
+      "post": {
+        "summary": "Load inhibitions from JSON",
+        "description": "Restore inhibitions from a previous JSON dump.",
+        "tags": [
+          "manage"
+        ],
+        "operationId": "loadInhibitions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "type": "array",
+              "schema": {
+                "$ref": "#/components/schemas/Inhibition"
               }
             }
           }

--- a/src/main/resources/ca/on/oicr/gsi/somnus/swagger.json
+++ b/src/main/resources/ca/on/oicr/gsi/somnus/swagger.json
@@ -1,8 +1,55 @@
 {
-  "components": {},
+  "components": {
+    "schemas": {
+      "Inhibition": {
+        "properties": {
+          "created": {
+            "type": "object",
+            "properties": {
+              "nano": {
+                "type": "number"
+              },
+              "epochSecond": {
+                "type": "number"
+              }
+            }
+          },
+          "creator": {
+            "type": "number"
+          },
+          "environment": {
+            "type": "string"
+          },
+          "expirationTime": {
+            "type": "object",
+            "properties": {
+              "nano": {
+                "type": "number"
+              },
+              "epochSecond": {
+                "type": "number"
+              }
+            }
+          },
+          "id": {
+            "type": "number"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
   "info": {
     "contact": {
-      "email": "andre.masella@oicr.on.ca"
+      "url": "https://github.com/oicr-gsi/somnus/issues/new"
     },
     "description": "This API is implemented by [Somnus](https://github.com/oicr-gsi/somnus).",
     "license": {
@@ -102,6 +149,26 @@
         "tags": [
           "manage"
         ]
+      },
+      "get": {
+        "summary": "Dump all inhibitions to JSON",
+        "description": "Get a JSON array of all inhibitions currently in memory in order to recreate on reboot.",
+        "tags": [
+          "manage"
+        ],
+        "responses": {
+          "200": {
+            "description": "JSON array of JSON representations of inhibitions.",
+            "content": {
+              "application/json": {
+                "type": "array",
+                "schema": {
+                  "$ref": "#/components/schemas/Inhibition"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
Add GET method to inhibitions endpoint which dumps all inhibitions in memory to JSON.
Add /load endpoint which accepts POST of said JSON, excluding any inhibitions which have expired during the downtime.
Convert Inhibition to be understood by Jackson because the static TTL value in CreateRequest is problematic for this purpose.

This is to help with IT Shutdowns.